### PR TITLE
Remove the temporary test badge

### DIFF
--- a/server/authentication.js
+++ b/server/authentication.js
@@ -91,10 +91,12 @@ module.exports.init = function (app) {
       if (badge.consumerKey && badge.consumerSecret) {
         strategy._oauth2._clientId = badge.consumerKey;
         strategy._oauth2._clientSecret = badge.consumerSecret;
+        // Construct the correct callback URL by taking the URL from the
+        // environment variable as baseline and appending /callback to the
+        // path this request was targeting.
         var parsedUrl = url.parse(process.env.AUTH0_CALLBACK_URL);
-        //parsedUrl.pathname = splitPath.slice(0, 3).concat('callback').join('/');
-        // TODO: Use above line once using real badges.
-        parsedUrl.pathname = '/badges/test/callback';
+        var splitPath = req.baseUrl.split('?')[0].split('/');
+        parsedUrl.pathname = splitPath.slice(0, 3).concat('callback').join('/');
         strategy._callbackURL = url.format(parsedUrl);
       } else {
         resetAuth0();

--- a/server/index.js
+++ b/server/index.js
@@ -64,21 +64,6 @@ app.use(session({
   resave: false
 }));
 
-// Temporary middleware to route URL with test badge
-// to some badge that exists in the database.
-app.use(function (req, res, next) {
-  if (req.url.indexOf('test') > 0) {
-    models.Badge.findOne(function (err, badge) {
-      if (!err && badge) {
-        req.url = req.url.replace('test', badge._id);
-      }
-      next();
-    });
-  } else {
-    next();
-  }
-});
-
 if (authentication.isEnabled()) {
   authentication.init(app);
 } else {


### PR DESCRIPTION
The test badge was useful to test integration with the iDEA hub since we had
only one badge URL configured there. Going forward, each badge will have a
unique URL and key/secret pair and they need to be configured separately
in the hub.